### PR TITLE
Feature: Add currency selection functionality

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
-    id("kotlin-kapt")
+    id("com.google.devtools.ksp") version "1.9.0-1.0.13"
 }
 
 android {
@@ -74,9 +74,8 @@ dependencies {
     implementation("com.maxkeppeler.sheets-compose-dialogs:calendar:1.3.0")
     implementation("com.maxkeppeler.sheets-compose-dialogs:clock:1.3.0")
     implementation("androidx.room:room-runtime:2.6.1")
-    kapt("androidx.room:room-compiler:2.6.1")
-    kapt("android.arch.persistence.room:compiler:1.1.1")
-    implementation("androidx.room:room-ktx:$2.6.1")
+    ksp("androidx.room:room-compiler:2.6.1")
+    implementation("androidx.room:room-ktx:2.6.1")
     implementation("androidx.compose.runtime:runtime-livedata:1.6.1")
     implementation("com.google.code.gson:gson:2.8.5")
 

--- a/app/src/main/java/com/example/friendsindeed/CurrencyManager.kt
+++ b/app/src/main/java/com/example/friendsindeed/CurrencyManager.kt
@@ -1,0 +1,47 @@
+package com.example.friendsindeed
+
+import android.content.Context
+
+object CurrencyManager {
+    private const val PREFS_NAME = "CurrencyPrefs"
+    private const val KEY_CURRENCY_SYMBOL = "currency_symbol"
+    private const val KEY_CURRENCY_CODE = "currency_code"
+    private const val DEFAULT_SYMBOL = "₹"
+    private const val DEFAULT_CODE = "INR"
+
+    data class Currency(val code: String, val symbol: String, val name: String)
+
+    val supportedCurrencies = listOf(
+        Currency("INR", "₹", "Indian Rupee"),
+        Currency("USD", "$", "US Dollar"),
+        Currency("EUR", "€", "Euro"),
+        Currency("GBP", "£", "British Pound"),
+        Currency("JPY", "¥", "Japanese Yen"),
+        Currency("AUD", "A$", "Australian Dollar"),
+        Currency("CAD", "C$", "Canadian Dollar")
+    )
+
+    fun getCurrencySymbol(context: Context): String {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        return prefs.getString(KEY_CURRENCY_SYMBOL, DEFAULT_SYMBOL) ?: DEFAULT_SYMBOL
+    }
+
+    fun getCurrencyCode(context: Context): String {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        return prefs.getString(KEY_CURRENCY_CODE, DEFAULT_CODE) ?: DEFAULT_CODE
+    }
+
+    fun setCurrency(context: Context, currency: Currency) {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        prefs.edit().apply {
+            putString(KEY_CURRENCY_SYMBOL, currency.symbol)
+            putString(KEY_CURRENCY_CODE, currency.code)
+            apply()
+        }
+    }
+
+    fun getCurrentCurrency(context: Context): Currency {
+        val code = getCurrencyCode(context)
+        return supportedCurrencies.find { it.code == code } ?: supportedCurrencies.first()
+    }
+}


### PR DESCRIPTION
Fixes #9 

- Add CurrencyManager utility class for managing currency preferences
- Add currency selection button in top bar (HomeScreen and UserScreen)
- Implement currency selection dialog with 7 supported currencies (INR, USD, EUR, GBP, JPY, AUD, CAD)
- Update all currency displays throughout the app to use selected currency symbol
- Persist currency preference using SharedPreferences
- Switch from KAPT to KSP (KAP has compatibility issues with newer java versions)